### PR TITLE
Calculate criticality

### DIFF
--- a/indicators/README.md
+++ b/indicators/README.md
@@ -42,3 +42,17 @@ Requires the following scripts to have run:
 
 * [road network data](../road-network)
 * [flood depths](../floods)
+
+
+## Segment Criticality
+Calculates the score of each segment based on their usage count in the routes from the origin to a given POI type (healthcare, education, etc)
+
+```
+$ bash indicators/segment-criticality.sh
+```
+
+### Pre-requisites
+Requires the following scripts to have run:
+
+* [road network data](../road-network)
+* [segments count](../segment-count)

--- a/indicators/segment-criticality.js
+++ b/indicators/segment-criticality.js
@@ -1,0 +1,68 @@
+const fs = require('fs-extra');
+const acsv = require('async-csv');
+
+const utils = require('../lib/indicators/utils');
+
+/**
+ *
+ * Usage:
+ *  $node ./indicators/segment-criticality [input-dir] [output-dir]
+ *
+ */
+
+// This script requires 3 parameters.
+const [, , INPUT_DIR, OUTPUT_DIR] = process.argv;
+
+if (!INPUT_DIR || !OUTPUT_DIR) {
+  console.log(`This script requires two parameters to run:
+  1. Input directory with files.
+  2. Directory where the output files should be stored.
+  
+  Eg. $node ./indicators/segment-criticality .tmp/segment-count .out/`);
+
+  process.exit(1);
+}
+
+async function main() {
+  const started = Date.now();
+
+  console.log('Creating way lookup index...');
+  // Create a lookup index for the road network ways.
+  const rnWays = await fs.readJSON(`${INPUT_DIR}/roadnetwork-osm-ways.json`);
+  const RN_WAYS_INDEX = rnWays.reduce((acc, w) => {
+    acc[w.tags.id] = w.tags;
+    return acc;
+  }, {});
+
+  const files = await fs.readdir(INPUT_DIR);
+  const countFiles = files.filter((f) => f.endsWith('-count.json'));
+
+  for (const file of countFiles) {
+    const odName = file.replace('-count.json', '');
+    console.log('Processing', odName);
+    const counts = await fs.readJSON(`${INPUT_DIR}/${file}`);
+
+    // Calculate indicator score.
+    const maxVal = Math.max(...Object.values(counts));
+    const indicator = Object.keys(counts).map((key) => {
+      return {
+        roadId: RN_WAYS_INDEX[key].roadId,
+        value: counts[key],
+        score: (counts[key] * 100) / maxVal,
+      }
+    });
+
+    const csvOut = await acsv.stringify(indicator, { header: true });
+    await fs.writeFile(`${OUTPUT_DIR}/${odName}.csv`, csvOut);
+
+    console.log('Processing complete. Saved as', `${OUTPUT_DIR}/${odName}.csv`);
+  }
+
+  return started;
+}
+
+main()
+  .then((startTime) =>
+    console.log('Done in %d seconds!', (Date.now() - startTime) / 1000)
+  )
+  .catch((err) => console.log('Error:', err));

--- a/indicators/segment-criticality.sh
+++ b/indicators/segment-criticality.sh
@@ -1,0 +1,25 @@
+# Project ID used to namepsace the files
+PROJECT_ID=haiti
+
+# S3 buckets, for input and output data
+S3_OUTPUT=road-data-production
+TMP_INPUT=./.tmp/$PROJECT_ID/input/indicators/segment-criticality
+TMP_OUTPUT=./.tmp/$PROJECT_ID/output/indicators/segment-criticality
+
+# echo 'Housekeeping and getting data from S3...'
+rm -rf $TMP_OUTPUT
+mkdir -p $TMP_INPUT
+mkdir -p $TMP_OUTPUT
+
+aws s3 cp s3://$S3_OUTPUT-$PROJECT_ID/roads/roadnetwork-osm-ways.json $TMP_INPUT
+aws s3 cp --recursive s3://$S3_OUTPUT-$PROJECT_ID/segment-count/ $TMP_INPUT
+
+node ./indicators/segment-criticality.js $TMP_INPUT $TMP_OUTPUT
+
+echo 'Copying the segment criticalilty indicators to s3://'$S3_OUTPUT'...'
+aws s3 cp --recursive \
+  $TMP_OUTPUT \
+  s3://$S3_OUTPUT-$PROJECT_ID/indicators/ \
+  --content-encoding gzip \
+  --acl public-read \
+  --quiet

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@turf/point-to-line-distance": "^6.0.0",
     "async-csv": "^2.1.3",
     "bluebird": "^3.7.2",
+    "cli-progress": "^3.8.2",
     "csv-stringify": "^5.3.6",
     "fs-extra": "^8.1.0",
     "geojson-stream": "^0.1.0",

--- a/segment-count/.gitignore
+++ b/segment-count/.gitignore
@@ -1,0 +1,6 @@
+/*.json
+/*.osm
+/rn
+/od-pairs
+/results
+profile.lua

--- a/segment-count/README.md
+++ b/segment-count/README.md
@@ -1,0 +1,102 @@
+# OD Pairs segment count
+This script calculates the amount of times a given segment is used for the given OD pairs. This is used to determine what the most important segments in a network are.
+It starts by calculating a route for each OD pair using the **fastest path** method according to the OSRM speed profile in `instance/osrm_profile-haiti` of the [road-planning-functions](https://github.com/developmentseed/road-planning-functions) repo, and then counts the segments using their id.
+
+Success example:
+```json
+{
+  "4":1,
+  "5":1,
+  "6":1,
+  "7":4,
+  "11":1,
+  "12":24
+  // ...
+}
+```
+
+Error example:
+```json
+  {
+    "o": 1,
+    "d": 4,
+    "coordinates": [
+      [
+        -72.96121440103624,
+        20.052509815160192
+      ],
+      [
+        -72.840367,
+        19.9378068
+      ]
+    ],
+    "error": "NoRoute"
+  }
+```
+## Data requirements
+
+### Road network
+**Getting the road-network**
+```
+aws s3 cp s3://road-data-production-haiti/roads/base-rn.osm road-network.osm
+```
+
+NOTE: Each way must have an `id` tag that uniquely identifies the way.
+
+To convert the road network to OSRM format:
+```bash
+# Profile need to be in directory for docker to access it
+cp ../lib/instance/osrm_profile-haiti.lua profile.lua
+
+# Run OSRM
+docker run -t -v "${PWD}:/data" developmentseed/osrm-backend:v5.22.0 osrm-extract -p /data/profile.lua /data/road-network.osm
+docker run -t -v "${PWD}:/data" developmentseed/osrm-backend:v5.22.0 osrm-partition /data/road-network.osrm
+docker run -t -v "${PWD}:/data" developmentseed/osrm-backend:v5.22.0 osrm-customize /data/road-network.osrm
+
+# Move things around
+mkdir rn
+mv road-network.osrm* rn
+```
+
+### OD pairs
+The od pairs file should follow the format described by [od-generator](https://github.com/developmentseed/od-generator).
+
+From od-generator docs:
+```
+{
+  "origins": {
+    "type": "FeatureCollection",
+    "features": []
+  },
+  "destinations": {
+    "type": "FeatureCollection",
+    "features": []
+  },
+  "pairs": [
+    {
+      "o": 1,
+      "d": 15
+    },
+    {
+      "o": 1,
+      "d": 16
+    }
+  ]
+}
+```
+
+**Getting the OD pairs**
+```
+aws s3 cp --recursive s3://road-data-input-haiti/od/ ./od-pairs
+```
+
+## Running the script
+Run the script with
+
+```
+node index.js
+```
+
+Upload to s3 with
+```
+aws s3 cp --recursive ./results s3://road-data-production-haiti/segment-count

--- a/segment-count/index.js
+++ b/segment-count/index.js
@@ -1,0 +1,130 @@
+const OSRM = require('osrm');
+const fs = require('fs-extra');
+const path = require('path');
+const Promise = require('bluebird');
+const cliProgress = require('cli-progress');
+const { count } = require('console');
+
+function osrmRoute(osrm, opts) {
+  return new Promise((resolve, reject) => {
+    osrm.route(opts, (err, res) => (err ? reject(err) : resolve(res)));
+  });
+}
+
+// File paths definition.
+const ODPAIRS_DIR = './od-pairs';
+const OSRM_FILE = './rn/road-network.osrm';
+const OSM_WAYS_FILE = './roadnetwork-osm-ways.json';
+const RESULTS_DIR = './results';
+
+async function main() {
+  const started = Date.now();
+
+  await fs.ensureDir(RESULTS_DIR);
+
+  const files = await fs.readdir(ODPAIRS_DIR);
+  const odPairsFiles = files.filter((f) => f.endsWith('.json'));
+
+  const osrm = new OSRM({
+    path: OSRM_FILE,
+    algorithm: 'MLD',
+  });
+
+  for (const file of odPairsFiles) {
+    await processOdPairFile(file, osrm);
+  }
+
+  return started;
+}
+
+async function processOdPairFile(file, osrm) {
+  const odName = file.replace('.json', '');
+  console.log('Processing', odName);
+  // Create progress bar.
+  const progressBar = new cliProgress.SingleBar(
+    {
+      format: 'routing {bar} {percentage}% | {value}/{total}',
+    },
+    cliProgress.Presets.shades_classic
+  );
+
+  const odPairs = await fs.readJSON(path.join(__dirname, 'od-pairs', file));
+  // Start with the number of pairs to process.
+  progressBar.start(odPairs.pairs.length, 0);
+
+  const result = await Promise.map(
+    odPairs.pairs,
+    calcOdPairRoute(odPairs, osrm, progressBar),
+    { concurrency: 10 }
+  );
+
+  progressBar.stop();
+
+  const [valid, errors] = result.reduce(
+    (split, v) => {
+      split[Number(!!v.error)].push(v);
+      return split;
+    },
+    [[], []]
+  );
+
+  const counts = valid.reduce((group, o) => {
+    o.routeSegments.forEach((id) => {
+      group[id] = (group[id] || 0) + 1;
+    });
+    return group;
+  }, {});
+
+  const errorFile = path.join(RESULTS_DIR, `${odName}-errors.json`);
+  console.log('Errors:', errors.length, ' - ', errorFile);
+  await fs.writeJSON(path.join(__dirname, errorFile), errors);
+
+  const resultsFile = path.join(RESULTS_DIR, `${odName}-count.json`);
+  console.log('Results:', resultsFile);
+  await fs.writeJSON(path.join(__dirname, resultsFile), counts);
+
+  console.log();
+}
+
+function calcOdPairRoute(lookup, osrm, progressBar) {
+  return async (pair) => {
+    const o = lookup.origins.features[pair.o];
+    const d = lookup.destinations.features[pair.d];
+
+    try {
+      const result = await osrmRoute(osrm, {
+        coordinates: [o.geometry.coordinates, d.geometry.coordinates],
+        overview: 'false',
+        steps: true,
+      });
+
+      const { legs } = result.routes[0];
+
+      const segmentIds = legs[0].steps.reduce((idsSet, leg) => {
+        idsSet.add(leg.name);
+        return idsSet;
+      }, new Set());
+
+      progressBar.increment();
+
+      return {
+        ...pair,
+        coordinates: [o.geometry.coordinates, d.geometry.coordinates],
+        routeSegments: Array.from(segmentIds),
+      };
+    } catch (error) {
+      progressBar.increment();
+      return {
+        ...pair,
+        coordinates: [o.geometry.coordinates, d.geometry.coordinates],
+        error: error.message,
+      };
+    }
+  };
+}
+
+main()
+  .then((startTime) =>
+    console.log('Done in %d seconds!', (Date.now() - startTime) / 1000)
+  )
+  .catch((err) => console.log('Error:', err));

--- a/yarn.lock
+++ b/yarn.lock
@@ -115,6 +115,11 @@ ansi-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
   integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
 
+ansi-regex@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
+  integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
+
 aproba@^1.0.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
@@ -163,6 +168,14 @@ chownr@^1.1.1:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
   integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
 
+cli-progress@^3.8.2:
+  version "3.8.2"
+  resolved "https://registry.yarnpkg.com/cli-progress/-/cli-progress-3.8.2.tgz#abaf1fc6d6401351f16f068117a410554a0eb8c7"
+  integrity sha512-qRwBxLldMSfxB+YGFgNRaj5vyyHe1yMpVeDL79c+7puGujdKJHQHydgqXDcrkvQgJ5U/d3lpf6vffSoVVUftVQ==
+  dependencies:
+    colors "^1.1.2"
+    string-width "^4.2.0"
+
 cliui@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-3.2.0.tgz#120601537a916d29940f934da3b48d585a39213d"
@@ -176,6 +189,11 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
+
+colors@^1.1.2:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
+  integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -276,6 +294,11 @@ domutils@^1.5.1:
   dependencies:
     dom-serializer "0"
     domelementtype "1"
+
+emoji-regex@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
+  integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
 entities@^1.1.1:
   version "1.1.2"
@@ -442,6 +465,11 @@ is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
   integrity sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=
+
+is-fullwidth-code-point@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
+  integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
 is-utf8@^0.2.0:
   version "0.2.1"
@@ -901,6 +929,15 @@ string-width@^1.0.1, string-width@^1.0.2:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
+string-width@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.0.tgz#952182c46cc7b2c313d1596e623992bd163b72b5"
+  integrity sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.0"
+
 string_decoder@^1.1.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
@@ -928,6 +965,13 @@ strip-ansi@^4.0.0:
   integrity sha1-qEeQIusaw2iocTibY1JixQXuNo8=
   dependencies:
     ansi-regex "^3.0.0"
+
+strip-ansi@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.0.tgz#0b1571dd7669ccd4f3e06e14ef1eed26225ae532"
+  integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
+  dependencies:
+    ansi-regex "^5.0.0"
 
 strip-bom@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Implements the approach detailed in #5 and #6 to calculate the score.

The code is divided in 2 parts:
- the `segment-count` script is responsible for calculating routes and the segment count
- the `segment-criticality` inside `indicators` calculates the indicator score from the files generated by the previous script

@olafveerman If you feel the files should be organized in a different way, or with other nomenclature, feel free to make a suggestion.

The results of the `segment-counts` can be found at `s3://road-data-production-haiti/segment-count/`.

The results of the `segment-criticality` can be found with the other indicators at  `s3://road-data-production-haiti/indicators/`.