### PR TITLE
Segment count

### DIFF
--- a/indicators/README.md
+++ b/indicators/README.md
@@ -44,11 +44,11 @@ Requires the following scripts to have run:
 * [flood depths](../floods)
 
 
-## Segment Criticality
+## Segment Usage
 Calculates the score of each segment based on their usage count in the routes from the origin to a given POI type (healthcare, education, etc)
 
 ```
-$ bash indicators/segment-criticality.sh
+$ bash indicators/segment-usage.sh
 ```
 
 ### Pre-requisites

--- a/indicators/segment-usage.js
+++ b/indicators/segment-usage.js
@@ -6,7 +6,7 @@ const utils = require('../lib/indicators/utils');
 /**
  *
  * Usage:
- *  $node ./indicators/segment-criticality [input-dir] [output-dir]
+ *  $node ./indicators/segment-usage [input-dir] [output-dir]
  *
  */
 
@@ -18,7 +18,7 @@ if (!INPUT_DIR || !OUTPUT_DIR) {
   1. Input directory with files.
   2. Directory where the output files should be stored.
   
-  Eg. $node ./indicators/segment-criticality .tmp/segment-count .out/`);
+  Eg. $node ./indicators/segment-usage .tmp/segment-count .out/`);
 
   process.exit(1);
 }

--- a/indicators/segment-usage.sh
+++ b/indicators/segment-usage.sh
@@ -3,8 +3,8 @@ PROJECT_ID=haiti
 
 # S3 buckets, for input and output data
 S3_OUTPUT=road-data-production
-TMP_INPUT=./.tmp/$PROJECT_ID/input/indicators/segment-criticality
-TMP_OUTPUT=./.tmp/$PROJECT_ID/output/indicators/segment-criticality
+TMP_INPUT=./.tmp/$PROJECT_ID/input/indicators/segment-usage
+TMP_OUTPUT=./.tmp/$PROJECT_ID/output/indicators/segment-usage
 
 # echo 'Housekeeping and getting data from S3...'
 rm -rf $TMP_OUTPUT
@@ -14,9 +14,9 @@ mkdir -p $TMP_OUTPUT
 aws s3 cp s3://$S3_OUTPUT-$PROJECT_ID/roads/roadnetwork-osm-ways.json $TMP_INPUT
 aws s3 cp --recursive s3://$S3_OUTPUT-$PROJECT_ID/segment-count/ $TMP_INPUT
 
-node ./indicators/segment-criticality.js $TMP_INPUT $TMP_OUTPUT
+node ./indicators/segment-usage.js $TMP_INPUT $TMP_OUTPUT
 
-echo 'Copying the segment criticalilty indicators to s3://'$S3_OUTPUT'...'
+echo 'Copying the segment usage indicators to s3://'$S3_OUTPUT'...'
 aws s3 cp --recursive \
   $TMP_OUTPUT \
   s3://$S3_OUTPUT-$PROJECT_ID/indicators/ \

--- a/road-network/README.md
+++ b/road-network/README.md
@@ -29,8 +29,10 @@ The script will do minor cleaning of the road segments, mostly of the properties
 `s3://[output_bucket]/roads/base-rn.osm`
 * **Vector Tiles**  
 `s3://[output_bucket]/roads/tiles/`
-* **OSRM routing graph**  
-`s3://[output_bucket]/roads/osrm/`
+* **OSRM routing graph - RUC based**  
+`s3://[output_bucket]/roads/osrm/ruc/`
+* **OSRM routing graph - speed based**  
+`s3://[output_bucket]/roads/osrm/speed/`
 * **Way index file**  
 `s3://[output_bucket]/roads/way_index.json`
 * **CSV to populate the database**  

--- a/road-network/road.sh
+++ b/road-network/road.sh
@@ -58,7 +58,7 @@ docker run -it --rm \
     -o /data/output/roads/base-rn.osm \
     --positive-id
 
-echo 'Generating the OSRM files...'
+echo 'Generating the OSRM files with the RUC profile...'
 cp $(pwd)/lib/instance/ruc-profile.lua $(pwd)/.tmp/$PROJECT_ID/input/roads
 
 # Run extract on the OSM XML
@@ -71,8 +71,8 @@ docker run -it --rm \
     /data/output/roads/base-rn.osm
 
 # Move OSRM files to folder for organization purposes
-mkdir ./.tmp/$PROJECT_ID/output/roads/osrm -p
-mv ./.tmp/$PROJECT_ID/output/roads/*.osrm* ./.tmp/$PROJECT_ID/output/roads/osrm/
+mkdir ./.tmp/$PROJECT_ID/output/roads/osrm/ruc -p
+mv ./.tmp/$PROJECT_ID/output/roads/*.osrm* ./.tmp/$PROJECT_ID/output/roads/osrm/ruc/
 
 # Run partition and customize
 docker run -it --rm \
@@ -80,14 +80,46 @@ docker run -it --rm \
   --user $(id -u):$(id -g) \
   developmentseed/osrm-backend:v5.22.0 \
   osrm-partition \
-    /data/output/roads/osrm/base-rn.osrm
+    /data/output/roads/osrm/ruc/base-rn.osrm
 
 docker run -it --rm \
   -v $(pwd)/.tmp/$PROJECT_ID/:/data \
   --user $(id -u):$(id -g) \
   developmentseed/osrm-backend:v5.22.0 \
   osrm-customize \
-    /data/output/roads/osrm/base-rn.osrm
+    /data/output/roads/osrm/ruc/base-rn.osrm
+
+
+echo 'Generating the OSRM files with the speed based profile...'
+cp $(pwd)/lib/instance/osrm_profile-haiti.lua $(pwd)/.tmp/$PROJECT_ID/input/roads
+
+# Run extract on the OSM XML
+docker run -it --rm \
+  -v $(pwd)/.tmp/$PROJECT_ID/:/data \
+  --user $(id -u):$(id -g) \
+  developmentseed/osrm-backend:v5.22.0 \
+  osrm-extract \
+    -p /data/input/roads/osrm_profile-haiti.lua \
+    /data/output/roads/base-rn.osm
+
+# Move OSRM files to folder for organization purposes
+mkdir ./.tmp/$PROJECT_ID/output/roads/osrm/speed -p
+mv ./.tmp/$PROJECT_ID/output/roads/*.osrm* ./.tmp/$PROJECT_ID/output/roads/osrm/speed/
+
+# Run partition and customize
+docker run -it --rm \
+  -v $(pwd)/.tmp/$PROJECT_ID/:/data \
+  --user $(id -u):$(id -g) \
+  developmentseed/osrm-backend:v5.22.0 \
+  osrm-partition \
+    /data/output/roads/osrm/speed/base-rn.osrm
+
+docker run -it --rm \
+  -v $(pwd)/.tmp/$PROJECT_ID/:/data \
+  --user $(id -u):$(id -g) \
+  developmentseed/osrm-backend:v5.22.0 \
+  osrm-customize \
+    /data/output/roads/osrm/speed/base-rn.osrm
 
 # Create a list of all ways with their nodes ids and properties
 echo 'Extract ways...'

--- a/segment-count/README.md
+++ b/segment-count/README.md
@@ -35,68 +35,13 @@ Error example:
 ```
 ## Data requirements
 
-### Road network
-**Getting the road-network**
-```
-aws s3 cp s3://road-data-production-haiti/roads/base-rn.osm road-network.osm
-```
-
-NOTE: Each way must have an `id` tag that uniquely identifies the way.
-
-To convert the road network to OSRM format:
-```bash
-# Profile need to be in directory for docker to access it
-cp ../lib/instance/osrm_profile-haiti.lua profile.lua
-
-# Run OSRM
-docker run -t -v "${PWD}:/data" developmentseed/osrm-backend:v5.22.0 osrm-extract -p /data/profile.lua /data/road-network.osm
-docker run -t -v "${PWD}:/data" developmentseed/osrm-backend:v5.22.0 osrm-partition /data/road-network.osrm
-docker run -t -v "${PWD}:/data" developmentseed/osrm-backend:v5.22.0 osrm-customize /data/road-network.osrm
-
-# Move things around
-mkdir rn
-mv road-network.osrm* rn
-```
-
-### OD pairs
-The od pairs file should follow the format described by [od-generator](https://github.com/developmentseed/od-generator).
-
-From od-generator docs:
-```
-{
-  "origins": {
-    "type": "FeatureCollection",
-    "features": []
-  },
-  "destinations": {
-    "type": "FeatureCollection",
-    "features": []
-  },
-  "pairs": [
-    {
-      "o": 1,
-      "d": 15
-    },
-    {
-      "o": 1,
-      "d": 16
-    }
-  ]
-}
-```
-
-**Getting the OD pairs**
-```
-aws s3 cp --recursive s3://road-data-input-haiti/od/ ./od-pairs
-```
+* base road network in `.osm` format
+* OSRM routing graph generated using the speed profile (as opposed to cost (RUC) based profile)
+* OD pairs following the format described by [od-generator](https://github.com/developmentseed/od-generator).
 
 ## Running the script
 Run the script with
 
 ```
-node index.js
+bash ./count.sh
 ```
-
-Upload to s3 with
-```
-aws s3 cp --recursive ./results s3://road-data-production-haiti/segment-count

--- a/segment-count/count.sh
+++ b/segment-count/count.sh
@@ -12,9 +12,9 @@ rm -rf $TMP_OUTPUT
 mkdir -p $TMP_INPUT
 mkdir -p $TMP_OUTPUT
 
-# aws s3 cp --recursive s3://$S3_INPUT/roads/base-rn.osm $TMP_INPUT/roads/base-rn.osm
-# aws s3 cp --recursive s3://$S3_OUTPUT/roads/osrm/speed $TMP_INPUT/roads/osrm/speed
-# aws s3 cp --recursive s3://$S3_INPUT/od $TMP_INPUT/od
+aws s3 cp --recursive s3://$S3_INPUT/roads/base-rn.osm $TMP_INPUT/roads/base-rn.osm
+aws s3 cp --recursive s3://$S3_OUTPUT/roads/osrm/speed $TMP_INPUT/roads/osrm/speed
+aws s3 cp --recursive s3://$S3_INPUT/od $TMP_INPUT/od
 
 echo 'Running the segment count for all OD pairs'
 node segment-count/index.js $TMP_INPUT $TMP_OUTPUT

--- a/segment-count/count.sh
+++ b/segment-count/count.sh
@@ -1,0 +1,30 @@
+# Project ID used to namepsace the files
+PROJECT_ID=haiti
+
+# S3 buckets, for input and output data
+S3_INPUT=road-data-input-$PROJECT_ID
+S3_OUTPUT=road-data-production-$PROJECT_ID
+TMP_INPUT=./.tmp/$PROJECT_ID/input
+TMP_OUTPUT=./.tmp/$PROJECT_ID/output/segment-count
+
+echo 'Housekeeping and getting data from S3...'
+rm -rf $TMP_OUTPUT
+mkdir -p $TMP_INPUT
+mkdir -p $TMP_OUTPUT
+
+# aws s3 cp --recursive s3://$S3_INPUT/roads/base-rn.osm $TMP_INPUT/roads/base-rn.osm
+# aws s3 cp --recursive s3://$S3_OUTPUT/roads/osrm/speed $TMP_INPUT/roads/osrm/speed
+# aws s3 cp --recursive s3://$S3_INPUT/od $TMP_INPUT/od
+
+echo 'Running the segment count for all OD pairs'
+node segment-count/index.js $TMP_INPUT $TMP_OUTPUT
+
+echo 'All output files stored in '$TMP_OUTPUT
+echo 'Syncing all files with '$S3_OUTPUT...
+aws s3 sync \
+  $TMP_OUTPUT \
+  s3://$S3_OUTPUT/segment-count \
+  --delete \
+  --content-encoding gzip \
+  --acl public-read \
+  --quiet

--- a/segment-count/index.js
+++ b/segment-count/index.js
@@ -11,11 +11,29 @@ function osrmRoute(osrm, opts) {
   });
 }
 
+/**
+ *
+ * Usage:
+ *  $node ./segment-count [input-dir] [output-dir]
+ *
+ */
+// This script requires 2 parameters.
+const [, , INPUT_DIR, OUTPUT_DIR] = process.argv;
+
+if (!INPUT_DIR || !OUTPUT_DIR) {
+  console.log(`This script requires two parameters to run:
+  1. Input directory with files.
+  2. Directory where the output files should be stored.
+
+  Eg. $node ./segment-count .tmp/segment-count .out/`);
+
+  process.exit(1);
+}
+
 // File paths definition.
-const ODPAIRS_DIR = './od-pairs';
-const OSRM_FILE = './rn/road-network.osrm';
-const OSM_WAYS_FILE = './roadnetwork-osm-ways.json';
-const RESULTS_DIR = './results';
+const ODPAIRS_DIR = `${INPUT_DIR}/od`;
+const OSRM_FILE = `${INPUT_DIR}/roads/osrm/speed/base-rn.osrm`;
+const RESULTS_DIR = OUTPUT_DIR;
 
 async function main() {
   const started = Date.now();
@@ -48,7 +66,7 @@ async function processOdPairFile(file, osrm) {
     cliProgress.Presets.shades_classic
   );
 
-  const odPairs = await fs.readJSON(path.join(__dirname, 'od-pairs', file));
+  const odPairs = await fs.readJSON(path.join(__dirname, `/../${ODPAIRS_DIR}`, file));
   // Start with the number of pairs to process.
   progressBar.start(odPairs.pairs.length, 0);
 
@@ -75,13 +93,13 @@ async function processOdPairFile(file, osrm) {
     return group;
   }, {});
 
-  const errorFile = path.join(RESULTS_DIR, `${odName}-errors.json`);
+  const errorFile = path.join(__dirname, `/../${RESULTS_DIR}`, `${odName}-errors.json`);
   console.log('Errors:', errors.length, ' - ', errorFile);
-  await fs.writeJSON(path.join(__dirname, errorFile), errors);
+  await fs.writeJSON(errorFile, errors);
 
-  const resultsFile = path.join(RESULTS_DIR, `${odName}-count.json`);
+  const resultsFile = path.join(__dirname, `/../${RESULTS_DIR}`, `${odName}-count.json`);
   console.log('Results:', resultsFile);
-  await fs.writeJSON(path.join(__dirname, resultsFile), counts);
+  await fs.writeJSON(resultsFile, counts);
 
   console.log();
 }


### PR DESCRIPTION
This PR does a couple of things:

* rename the segment criticality to segment count. This aims to reduce confusion with the new criticality indicator that's being added in #33 
* add a bash script to the segment count with all the usual glue. The goal is to reduce potential error with input data, and ensure the full pipeline is run with the same data
* add the speed based OSRM profile to the road processing. The goal is the same as ^, ensure the same input data is consumed along the whole pipeline

## Segment Usage - Markets
This branch was used to generate the segment usage indicator for markets. I did the following to generate it:

1. Generate GeoJSON from the Market data provided by the WB  
`ogr2ogr -f "GeoJSON" market.geojson  ~/Downloads/market/Marches_Haiti_IICA1977.shp -t_srs EPSG:4326`
2. Generate GeoJSON for the populated place data
`ogr2ogr -f "GeoJSON" places.geojson  ~/Downloads/population/'MT_104_Populated Places CNIGS.shp' -t_srs EPSG:4326`
3. Generate OD pairs from markets to settlements  
`yarn od generate -m closest places.geojson market.geojson`
4. Upload result to S3  
`aws s3 cp odpairs.json s3://road-data-input-haiti/od/od-market.json`  
`aws s3 cp market.geojson s3://road-data-input-haiti/poi/market.geojson`  
`aws s3 cp places.geojson s3://road-data-input-haiti/population/places.geojson`
5. Run the script to generate segment counts  
`bash segment-count/count.sh`
6. Generate the indicator data  
`bash indicators/segment-usage.sh`