### PR TITLE
Add score to floods

### DIFF
--- a/floods/depth.sh
+++ b/floods/depth.sh
@@ -9,7 +9,7 @@ TMP_OUTPUT=./.tmp/$PROJECT_ID/output/floods
 
 RETURN_PERIODS=(5 10 20 50 75 100 200 250 500 1000)
 # FLOOD_TYPES=(FD FU PD PU)
-FLOOD_TYPES=(FU)
+FLOOD_TYPES=(FU PU)
 
 echo 'Housekeeping and getting data from S3...'
 rm -rf ./.tmp/$PROJECT_ID/output/floods/

--- a/indicators/flood-hazard.sh
+++ b/indicators/flood-hazard.sh
@@ -7,7 +7,8 @@ S3_OUTPUT=road-data-production
 TMP_INPUT=./.tmp/$PROJECT_ID/input/indicators/flood
 TMP_OUTPUT=./.tmp/$PROJECT_ID/output/indicators/flood
 
-FLOOD_TYPES=(FU FD PU PD)
+# FLOOD_TYPES=(FU FD PU PD)
+FLOOD_TYPES=(FU PU)
 
 echo 'Housekeeping and getting data from S3...'
 rm -rf $TMP_OUTPUT


### PR DESCRIPTION
This PR adds a score to the floods, using logscale.

Because we need to have all road segments in memory to add a score, I removed the streaming approach.

## Result
The output looks like:

``` csv
roadId,value,score
RA100099-0,0,0
RA070739-16,0,0
RA100010-17,1491.746666666667,67.96
```

The script was used to generate new data for all flood types. The CSV are available on: `s3://road-data-production-haiti/indicators/`